### PR TITLE
CORE-8407: ES v5.0 Upgrade

### DIFF
--- a/src/infosquito/es_crawler.clj
+++ b/src/infosquito/es_crawler.clj
@@ -20,7 +20,7 @@
   (let [res (esd/search es index (name item-type)
               :query       (q/match-all)
               :fields      ["_id"]
-              :search_type "scan"
+              :sort        ["_doc"]
               :scroll      "1m"
               :size        (cfg/get-es-scroll-size props))]
     (if (resp/any-hits? res)

--- a/src/infosquito/es_crawler.clj
+++ b/src/infosquito/es_crawler.clj
@@ -19,7 +19,7 @@
   ; search types. A second call is needed to kick off the sequence.
   (let [res (esd/search es index (name item-type)
               :query       (q/match-all)
-              :fields      ["_id"]
+              :_source     ["_id"]
               :sort        ["_doc"]
               :scroll      "1m"
               :size        (cfg/get-es-scroll-size props))]


### PR DESCRIPTION
This PR contains updates to the terrain service to ensure that it's search features are API compatible with ES v5.0. The list below describes the [API Breaking Changes](https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-5.0.html) which were fixed as part of this PR.

- [x] `fields` parameter changed
- [x] `search_type=scan` removed