### PR TITLE
Add ability to use basic auth with Elasticsearch

### DIFF
--- a/dev-resources/local.properties
+++ b/dev-resources/local.properties
@@ -1,7 +1,7 @@
 infosquito.es.uri             = http://elastic-host:9200
-infosquito.es.host            = elastic-host
-infosquito.es.port            = 9200
 infosquito.es.index           = data-test
+infosquito.es.user            = default_username
+infosquito.es.password        = qwerty
 infosquito.es.scroll-size     = 1m
 infosquito.icat.host          = icat-host
 infosquito.icat.port          = 5432

--- a/infosquito.properties.tmpl
+++ b/infosquito.properties.tmpl
@@ -1,7 +1,5 @@
 {{- with $base := (printf "configs/%s" (env "DE_ENV")) -}}
 {{ with $v := (key (printf "%s/elasticsearch/base" $base )) }}infosquito.es.uri = {{ $v }}{{ end }}
-{{ with $v := (key (printf "%s/elasticsearch/host" $base )) }}infosquito.es.host = {{ $v }}{{ end }}
-{{ with $v := (key (printf "%s/elasticsearch/port" $base )) }}infosquito.es.port = {{ $v }}{{ end }}
 {{ with $v := (key (printf "%s/elasticsearch/data-alias" $base )) }}infosquito.es.index = {{ $v }}{{ end }}
 {{ with $v := (key (printf "%s/elasticsearch/scroll-size" $base )) }}infosquito.es.scroll-size = {{ $v }}{{ end }}
 

--- a/infosquito.properties.tmpl
+++ b/infosquito.properties.tmpl
@@ -1,5 +1,7 @@
 {{- with $base := (printf "configs/%s" (env "DE_ENV")) -}}
 {{ with $v := (key (printf "%s/elasticsearch/base" $base )) }}infosquito.es.uri = {{ $v }}{{ end }}
+{{ with $v := (key (printf "%s/elasticsearch/username" $base )) }}infosquito.es.user = {{ $v }}{{ end }}
+{{ with $v := (key (printf "%s/elasticsearch/password" $base )) }}infosquito.es.password = {{ $v }}{{ end }}
 {{ with $v := (key (printf "%s/elasticsearch/data-alias" $base )) }}infosquito.es.index = {{ $v }}{{ end }}
 {{ with $v := (key (printf "%s/elasticsearch/scroll-size" $base )) }}infosquito.es.scroll-size = {{ $v }}{{ end }}
 

--- a/src/infosquito/actions.clj
+++ b/src/infosquito/actions.clj
@@ -12,6 +12,8 @@
    :icat-password    (cfg/get-icat-pass p)
    :collection-base  (cfg/get-base-collection p)
    :es-url           (cfg/get-es-uri p)
+   :es-user          (cfg/get-es-user p)
+   :es-password      (cfg/get-es-password p)
    :es-index         (cfg/get-es-index p)
    :notify?          (cfg/notify-enabled? p)
    :notify-count     (cfg/get-notify-count p)

--- a/src/infosquito/es.clj
+++ b/src/infosquito/es.clj
@@ -45,9 +45,12 @@
   "Throws:
     :connection-refused - This is thrown if a connection cannot be established
       to Elastic Search"
-  [es-url]
+  [es-url es-user es-password]
   (ss/try+
-    (->Indexer (cer/connect es-url))
+    (let [http-opts (if (or (empty? es-user) (empty? es-password))
+                      {}
+                      {:basic-auth [es-user es-password]})]
+      (->Indexer (cer/connect es-url http-opts)))
     (catch ConnectException e
       (ss/throw+ {:type :connection-refused 
                   :msg (str "Cannot connect to Elastic Search. " 

--- a/src/infosquito/es_crawler.clj
+++ b/src/infosquito/es_crawler.clj
@@ -103,7 +103,11 @@
 (defn purge-index
   [props]
   (icat/reset-existence-cache)
-  (let [es (esr/connect (cfg/get-es-uri props))]
+  (let [http-opts (if (or (empty? (cfg/get-es-user props)) (empty? (cfg/get-es-password props)))
+                    {}
+                    {:basic-auth [(cfg/get-es-user props) (cfg/get-es-password props)]})
+        es (esr/connect (cfg/get-es-uri props) http-opts)]
     (purge-deleted-files es props)
     (purge-deleted-folders es props))
   (icat/reset-existence-cache))
+

--- a/src/infosquito/icat.clj
+++ b/src/infosquito/icat.clj
@@ -366,7 +366,7 @@
 
 (defn reindex
   [cfg]
-  (let [indexer (es/mk-indexer (:es-url cfg))]
+  (let [indexer (es/mk-indexer (:es-url cfg) (:es-user cfg) (:es-password cfg))]
     (index-collections cfg indexer)
     (index-data-objects cfg indexer)))
 

--- a/src/infosquito/props.clj
+++ b/src/infosquito/props.clj
@@ -61,6 +61,14 @@
   [props]
   (get-str props "infosquito.es.uri"))
 
+(defn get-es-user
+  [props]
+  (get-str props "infosquito.es.user"))
+
+(defn get-es-password
+  [props]
+  (get-str props "infosquito.es.password"))
+
 (defn get-es-index
   [props]
   (get-str props "infosquito.es.index"))

--- a/src/infosquito/props.clj
+++ b/src/infosquito/props.clj
@@ -10,8 +10,6 @@
 
 (def ^:private prop-defaults
   {"infosquito.es.uri"                    "http://elasticsearch:9200"
-   "infosquito.es.host"                   "elasticsearch"
-   "infosquito.es.port"                   "9200"
    "infosquito.es.index"                  "data"
    "infosquito.es.scroll-size"            "1000"
    "infosquito.icat.host"                 "irods"
@@ -58,15 +56,6 @@
         (System/exit 1)))
     (get prop-defaults prop-name)))
 
-
-(defn get-es-host
-  [props]
-  (get-str props "infosquito.es.host"))
-
-
-(defn get-es-port
-  [props]
-  (get-str props "infosquito.es.port"))
 
 (defn get-es-uri
   [props]

--- a/test/infosquito/props_test.clj
+++ b/test/infosquito/props_test.clj
@@ -18,12 +18,6 @@
 (deftest test-get-es-uri
   (is (= "http://elastic-host:9200" (get-es-uri props))))
 
-(deftest test-get-es-host
-  (is (= "elastic-host" (get-es-host props))))
-
-(deftest test-get-es-port
-  (is (= "9200" (get-es-port props))))
-
 (deftest test-get-es-index
   (is (= "data-test" (get-es-index props))))
 
@@ -59,12 +53,6 @@
 
 (deftest test-get-default-es-uri
   (is (= "http://elasticsearch:9200" (get-es-uri bad-props))))
-
-(deftest test-get-default-es-host
-  (is (= "elasticsearch" (get-es-host bad-props))))
-
-(deftest test-get-default-es-port
-  (is (= "9200" (get-es-port bad-props))))
 
 (deftest test-get-default-es-index
   (is (= "data" (get-es-index bad-props))))

--- a/test/infosquito/props_test.clj
+++ b/test/infosquito/props_test.clj
@@ -18,6 +18,12 @@
 (deftest test-get-es-uri
   (is (= "http://elastic-host:9200" (get-es-uri props))))
 
+(deftest test-get-es-user
+  (is (= "default_username" (get-es-user props))))
+
+(deftest test-get-es-password
+  (is (= "qwerty" (get-es-password props))))
+
 (deftest test-get-es-index
   (is (= "data-test" (get-es-index props))))
 


### PR DESCRIPTION
Additionally removed the unused `host` and `port` Elasticseach config variables.

Intended behavior is to only use the basic auth when the configuration supplied Elasticsearch username and password are non-empty.